### PR TITLE
allow user groups to work out of order

### DIFF
--- a/include/auth.php
+++ b/include/auth.php
@@ -103,7 +103,8 @@ class Authentication {
 			}
 			foreach ($this->usersGroups as $users_group) {
 				foreach ($groups as $group => $names) {
-					if (in_array($users_group, preg_split('/\s*,\s*/', $names))) {
+					if (in_array($users_group, preg_split('/\s*,\s*/', $names))
+					   && !in_array('@'.$group, $this->usersGroups)) {
 						$this->usersGroups[] = '@'.$group;
 					}
 				}

--- a/include/auth.php
+++ b/include/auth.php
@@ -100,8 +100,9 @@ class Authentication {
 				if (in_array(strtolower($this->user), preg_split('/\s*,\s*/', $names))) {
 					$this->usersGroups[] = '@'.$group;
 				}
-
-				foreach ($this->usersGroups as $users_group) {
+			}
+			foreach ($this->usersGroups as $users_group) {
+				foreach ($groups as $group => $names) {
 					if (in_array($users_group, preg_split('/\s*,\s*/', $names))) {
 						$this->usersGroups[] = '@'.$group;
 					}


### PR DESCRIPTION
If the svn_authz file has:
```
Group1 = @Group2
Group2 = user1
```
Then user1 would not be seen in Group1, this allows this to work. Circular nested groups may cause a problem, but you shouldn't be doing that...